### PR TITLE
Fixing the mis-interpreted bad slope flag.

### DIFF
--- a/codebase/superdarn/src.lib/tk/fitacf.2.5/src/fit_acf.c
+++ b/codebase/superdarn/src.lib/tk/fitacf.2.5/src/fit_acf.c
@@ -403,7 +403,7 @@ int fit_acf (struct complex *acf,int range,
 
   if (fabs(omega_high - omega_low) >= 2*ptr->v_err) {
     ptr->v = omega_base;
-    ptr->v_err = fabs(omega_high - omega_low);
+    ptr->v_err = - ptr->v_err;
     }
   }
   


### PR DESCRIPTION
This fix was developed Pasha and approved by the Data Analysis Working Group (DAWG) and recorded as Task#2 on the DAWG webpage.

https://homepage.usask.ca/~pbp672/Data_Analysis_WG_Task2_Bad_phase_flag.pdf

Note: We replaced a bad slope flag value of 9999 by the negative phase fitting error. 
