### PR TITLE
Making backwards compatible with RST2.x

### DIFF
--- a/codebase/superdarn/src.idl/lib/legacy.1.6/rbposlib.pro
+++ b/codebase/superdarn/src.idl/lib/legacy.1.6/rbposlib.pro
@@ -100,7 +100,7 @@ function rbpos,range,height=height,beam=beam,lagfr=first_lag,smsep=smsp, $
       stop
     endif
     s=RadarLoadHardware(network,path=getenv('SD_HDWPATH'))
-    if (s le 0) then begin
+    if (s ne 0) then begin
       print, 'Could not load hardware information'
       stop
     endif


### PR DESCRIPTION
As identified by Rob Fear, the if statement in the older version of RST looks for a value of not zero.  This is despite the fact that RadarLoadHardware should always return zero as noted in the header file of: `codebase/superdarn/src.idl/lib/main.1.24/radar.pro`

The change here makes things compatible with the older version of RST.