### PR TITLE
Bugfix fitstat

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/fitstat.1.6/fitstat.c
+++ b/codebase/superdarn/src.bin/tk/tool/fitstat.1.6/fitstat.c
@@ -88,6 +88,8 @@ int main (int argc,char *argv[]) {
   int bmcnt;
   int stid;
 
+  prm=RadarParmMake();
+
   OptionAdd(&opt,"-help",'x',&help);
   OptionAdd(&opt,"-option",'x',&option);
 

--- a/codebase/superdarn/src.bin/tk/tool/fitstat.1.6/fitstat.c
+++ b/codebase/superdarn/src.bin/tk/tool/fitstat.1.6/fitstat.c
@@ -5,26 +5,26 @@
 
 /*
  LICENSE AND DISCLAIMER
- 
+
  Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- 
+
  This file is part of the Radar Software Toolkit (RST).
- 
+
  RST is free software: you can redistribute it and/or modify
  it under the terms of the GNU Lesser General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  any later version.
- 
+
  RST is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU Lesser General Public License for more details.
- 
+
  You should have received a copy of the GNU Lesser General Public License
  along with RST.  If not, see <http://www.gnu.org/licenses/>.
- 
- 
- 
+
+
+
 */
 
 /*Generates statistics from fit files*/
@@ -65,7 +65,7 @@ int main (int argc,char *argv[]) {
 
 /* File format transistion
    * ------------------------
-   * 
+   *
    * When we switch to the new file format remove any reference
    * to "new". Change the command line option "new" to "old" and
    * remove "old=!new".
@@ -78,21 +78,21 @@ int main (int argc,char *argv[]) {
   int arg;
   unsigned char help=0;
   unsigned char option=0;
-  
+
   struct OldFitFp *fitfp=NULL;
   FILE *fp=NULL;
-  
+
 
   int yr,mo,dy,hr,mt;
   double sc,st_time,ed_time;
   int bmcnt;
   int stid;
-  
+
   OptionAdd(&opt,"-help",'x',&help);
   OptionAdd(&opt,"-option",'x',&option);
 
 
-  OptionAdd(&opt,"new",'x',&new); 
+  OptionAdd(&opt,"new",'x',&new);
 
   arg=OptionProcess(1,argc,argv,&opt,NULL);
 
@@ -115,10 +115,10 @@ int main (int argc,char *argv[]) {
     exit(-1);
   }
 
- 
+
   if (old) {
 
-    fitfp=OldFitOpen(argv[arg],NULL); 
+    fitfp=OldFitOpen(argv[arg],NULL);
     if (fitfp==NULL) {
       fprintf(stderr,"file %s not found\n",argv[arg]);
       exit(1);
@@ -130,8 +130,8 @@ int main (int argc,char *argv[]) {
     while (OldFitRead(fitfp,prm,fit) !=-1) {
       ed_time=TimeYMDHMSToEpoch(prm->time.yr,prm->time.mo,prm->time.dy,
              prm->time.hr,prm->time.mt,prm->time.sc);
-      
-    
+
+
       if (bmcnt==0) {
         st_time=ed_time;
         stid=prm->stid;
@@ -185,26 +185,5 @@ int main (int argc,char *argv[]) {
   }
   exit(0);
   return 0;
-} 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+}
 

--- a/codebase/superdarn/src.bin/tk/tool/fitstat.1.6/fitstat.c
+++ b/codebase/superdarn/src.bin/tk/tool/fitstat.1.6/fitstat.c
@@ -140,7 +140,7 @@ int main (int argc,char *argv[]) {
     }
     if (bmcnt>0) {
 
-     fprintf(stdout,"%s:",argv[arg]);
+      fprintf(stdout,"%s:",argv[arg]);
       TimeEpochToYMDHMS(st_time,&yr,&mo,&dy,&hr,&mt,&sc);
       fprintf(stdout,"%.4d %.2d %.2d %.2d %.2d %.2d",yr,mo,dy,hr,mt,(int) sc);
       TimeEpochToYMDHMS(ed_time,&yr,&mo,&dy,&hr,&mt,&sc);
@@ -151,26 +151,29 @@ int main (int argc,char *argv[]) {
     } else exit(2);
     OldFitClose(fitfp);
   } else {
+    fprintf(stdout,"We're in the new part, mate. \n");
     fp=fopen(argv[arg],"r");
     if (fp==NULL) {
       fprintf(stderr,"Could not open file.\n");
       exit(1);
     }
+    fprintf(stdout,"Got the file open \n");
     bmcnt=0;
     st_time=-1;
     ed_time=-1;
     stid=0;
     while (FitFread(fp,prm,fit) !=-1) {
+      fprintf(stdout,"In the while loop, readin some data. \n");
       ed_time=TimeYMDHMSToEpoch(prm->time.yr,prm->time.mo,prm->time.dy,
                prm->time.hr,prm->time.mt,prm->time.sc);
-
+      fprintf(stdout,"Grabbed some time info \n");
       if (bmcnt==0) {
         st_time=ed_time;
         stid=prm->stid;
       }
       bmcnt++;
     }
-
+    fprintf(stdout,"Done loopin \n");
     if (bmcnt>0) {
       fprintf(stdout,"%s:",argv[arg]);
       TimeEpochToYMDHMS(st_time,&yr,&mo,&dy,&hr,&mt,&sc);
@@ -180,7 +183,10 @@ int main (int argc,char *argv[]) {
       fprintf(stdout,"%.4d %.2d %.2d %.2d %.2d %.2d ",yr,mo,dy,hr,mt,
                         (int) sc);
       fprintf(stdout,"[%.2d] (%d)\n",stid,bmcnt);
-    } else exit(1);
+    } else {
+        fprintf(stderr,"Error, no beams read\n");
+        exit(1);
+    }
     fclose(fp);
   }
   exit(0);

--- a/codebase/superdarn/src.bin/tk/tool/fitstat.1.6/fitstat.c
+++ b/codebase/superdarn/src.bin/tk/tool/fitstat.1.6/fitstat.c
@@ -89,6 +89,7 @@ int main (int argc,char *argv[]) {
   int stid;
 
   prm=RadarParmMake();
+  fit=FitMake();
 
   OptionAdd(&opt,"-help",'x',&help);
   OptionAdd(&opt,"-option",'x',&option);
@@ -150,32 +151,30 @@ int main (int argc,char *argv[]) {
       fprintf(stdout,"%.4d %.2d %.2d %.2d %.2d %.2d ",yr,mo,dy,hr,mt,
                         (int) sc);
       fprintf(stdout,"[%.2d] (%d)\n",stid,bmcnt);
-    } else exit(2);
+    } else {
+        fprintf(stderr,"Error, no beams read. bmcnt is: %d\n",bmcnt);
+        exit(2);
+    }
     OldFitClose(fitfp);
   } else {
-    fprintf(stdout,"We're in the new part, mate. \n");
     fp=fopen(argv[arg],"r");
     if (fp==NULL) {
       fprintf(stderr,"Could not open file.\n");
       exit(1);
     }
-    fprintf(stdout,"Got the file open \n");
     bmcnt=0;
     st_time=-1;
     ed_time=-1;
     stid=0;
     while (FitFread(fp,prm,fit) !=-1) {
-      fprintf(stdout,"In the while loop, readin some data. \n");
       ed_time=TimeYMDHMSToEpoch(prm->time.yr,prm->time.mo,prm->time.dy,
                prm->time.hr,prm->time.mt,prm->time.sc);
-      fprintf(stdout,"Grabbed some time info \n");
       if (bmcnt==0) {
         st_time=ed_time;
         stid=prm->stid;
       }
       bmcnt++;
     }
-    fprintf(stdout,"Done loopin \n");
     if (bmcnt>0) {
       fprintf(stdout,"%s:",argv[arg]);
       TimeEpochToYMDHMS(st_time,&yr,&mo,&dy,&hr,&mt,&sc);
@@ -186,7 +185,7 @@ int main (int argc,char *argv[]) {
                         (int) sc);
       fprintf(stdout,"[%.2d] (%d)\n",stid,bmcnt);
     } else {
-        fprintf(stderr,"Error, no beams read\n");
+        fprintf(stderr,"Error, no beams read. bmcnt is: %d\n",bmcnt);
         exit(1);
     }
     fclose(fp);

--- a/codebase/superdarn/src.lib/tk/fit.1.35/src/fitread.c
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/src/fitread.c
@@ -97,7 +97,6 @@ int FitDecode(struct DataMap *ptr,
         (a->dim==1)) xcf=1;
   }
 
-
   FitSetRng(fit,nrang);
   if (xcf) {
     FitSetXrng(fit,nrang);

--- a/codebase/superdarn/src.lib/tk/fit.1.35/src/fitread.c
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/src/fitread.c
@@ -1,30 +1,30 @@
 /* fitread.c
-   ========= 
+   =========
    Author: R.J.Barnes
 */
 
 /*
  LICENSE AND DISCLAIMER
- 
+
  Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- 
+
  This file is part of the Radar Software Toolkit (RST).
- 
+
  RST is free software: you can redistribute it and/or modify
  it under the terms of the GNU Lesser General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  any later version.
- 
+
  RST is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU Lesser General Public License for more details.
- 
+
  You should have received a copy of the GNU Lesser General Public License
  along with RST.  If not, see <http://www.gnu.org/licenses/>.
- 
- 
- 
+
+
+
 */
 
 #include <stdio.h>
@@ -66,7 +66,7 @@ int FitDecode(struct DataMap *ptr,
 
   for (c=0;c<ptr->snum;c++) {
     s=ptr->scl[c];
-   
+
     if ((strcmp(s->name,"fitacf.revision.major")==0) && (s->type==DATAINT))
       fit->revision.major=*(s->data.iptr);
     if ((strcmp(s->name,"fitacf.revision.minor")==0) && (s->type==DATAINT))
@@ -79,7 +79,7 @@ int FitDecode(struct DataMap *ptr,
     if ((strcmp(s->name,"noise.vel")==0) && (s->type==DATAFLOAT))
       fit->noise.vel=*(s->data.fptr);
   }
- 
+
   for (c=0;c<ptr->anum;c++) {
     a=ptr->arr[c];
 
@@ -97,13 +97,13 @@ int FitDecode(struct DataMap *ptr,
         (a->dim==1)) xcf=1;
   }
 
- 
+
   FitSetRng(fit,nrang);
   if (xcf) {
     FitSetXrng(fit,nrang);
     FitSetElv(fit,nrang);
-  } 
-  
+  }
+
   for (c=0;c<ptr->anum;c++) {
 
     a=ptr->arr[c];
@@ -119,7 +119,7 @@ int FitDecode(struct DataMap *ptr,
         (a->dim==1)) {
       for (x=0;x<a->rng[0];x++) fit->rng[slist[x]].nump=a->data.sptr[x];
     }
-    
+
     if ((strcmp(a->name,"qflg")==0) && (a->type==DATACHAR) &&
         (a->dim==1)) {
       qflg=1;
@@ -137,7 +137,7 @@ int FitDecode(struct DataMap *ptr,
     }
     if ((strcmp(a->name,"p_l_e")==0) && (a->type==DATAFLOAT) &&
         (a->dim==1)) {
-      for (x=0;x<a->rng[0];x++) 
+      for (x=0;x<a->rng[0];x++)
         fit->rng[slist[x]].p_l_err=a->data.fptr[x];
     }
 
@@ -147,7 +147,7 @@ int FitDecode(struct DataMap *ptr,
     }
     if ((strcmp(a->name,"p_s_e")==0) && (a->type==DATAFLOAT) &&
         (a->dim==1)) {
-      for (x=0;x<a->rng[0];x++) 
+      for (x=0;x<a->rng[0];x++)
         fit->rng[slist[x]].p_s_err=a->data.fptr[x];
     }
 
@@ -166,7 +166,7 @@ int FitDecode(struct DataMap *ptr,
     }
     if ((strcmp(a->name,"w_l_e")==0) && (a->type==DATAFLOAT) &&
         (a->dim==1)) {
-      for (x=0;x<a->rng[0];x++) 
+      for (x=0;x<a->rng[0];x++)
         fit->rng[slist[x]].w_l_err=a->data.fptr[x];
     }
 
@@ -176,57 +176,57 @@ int FitDecode(struct DataMap *ptr,
     }
     if ((strcmp(a->name,"w_s_e")==0) && (a->type==DATAFLOAT) &&
         (a->dim==1)) {
-      for (x=0;x<a->rng[0];x++) 
+      for (x=0;x<a->rng[0];x++)
         fit->rng[slist[x]].w_s_err=a->data.fptr[x];
     }
 
     if ((strcmp(a->name,"sd_l")==0) && (a->type==DATAFLOAT) &&
         (a->dim==1)) {
-      for (x=0;x<a->rng[0];x++) 
+      for (x=0;x<a->rng[0];x++)
         fit->rng[slist[x]].sdev_l=a->data.fptr[x];
     }
     if ((strcmp(a->name,"sd_s")==0) && (a->type==DATAFLOAT) &&
         (a->dim==1)) {
-      for (x=0;x<a->rng[0];x++) 
+      for (x=0;x<a->rng[0];x++)
         fit->rng[slist[x]].sdev_s=a->data.fptr[x];
     }
     if ((strcmp(a->name,"sd_phi")==0) && (a->type==DATAFLOAT) &&
         (a->dim==1)) {
-      for (x=0;x<a->rng[0];x++) 
+      for (x=0;x<a->rng[0];x++)
 	fit->rng[slist[x]].sdev_phi=a->data.fptr[x];
     }
 
     if (!xcf) continue;
-    
+
     if ((strcmp(a->name,"x_qflg")==0) && (a->type==DATACHAR) &&
-        (a->dim==1)) { 
+        (a->dim==1)) {
       xqflg=1;
       for (x=0;x<a->rng[0];x++) fit->xrng[slist[x]].qflg=a->data.cptr[x];
     }
-   
+
     if ((strcmp(a->name,"x_gflg")==0) && (a->type==DATACHAR) &&
         (a->dim==1)) {
       for (x=0;x<a->rng[0];x++) fit->xrng[slist[x]].gsct=a->data.cptr[x];
     }
-    
+
     if ((strcmp(a->name,"x_p_l")==0) && (a->type==DATAFLOAT) &&
         (a->dim==1)) {
       for (x=0;x<a->rng[0];x++) fit->xrng[slist[x]].p_l=a->data.fptr[x];
     }
-    
+
     if ((strcmp(a->name,"x_p_l_e")==0) && (a->type==DATAFLOAT) &&
         (a->dim==1)) {
-      for (x=0;x<a->rng[0];x++) 
+      for (x=0;x<a->rng[0];x++)
         fit->xrng[slist[x]].p_l_err=a->data.fptr[x];
     }
-    
+
     if ((strcmp(a->name,"x_p_s")==0) && (a->type==DATAFLOAT) &&
         (a->dim==1)) {
       for (x=0;x<a->rng[0];x++) fit->xrng[slist[x]].p_s=a->data.fptr[x];
     }
     if ((strcmp(a->name,"x_p_s_e")==0) && (a->type==DATAFLOAT) &&
         (a->dim==1)) {
-      for (x=0;x<a->rng[0];x++) 
+      for (x=0;x<a->rng[0];x++)
          fit->xrng[slist[x]].p_s_err=a->data.fptr[x];
     }
 
@@ -245,7 +245,7 @@ int FitDecode(struct DataMap *ptr,
     }
     if ((strcmp(a->name,"x_w_l_e")==0) && (a->type==DATAFLOAT) &&
         (a->dim==1)) {
-      for (x=0;x<a->rng[0];x++) 
+      for (x=0;x<a->rng[0];x++)
         fit->xrng[slist[x]].w_l_err=a->data.fptr[x];
     }
 
@@ -255,7 +255,7 @@ int FitDecode(struct DataMap *ptr,
     }
     if ((strcmp(a->name,"x_w_s_e")==0) && (a->type==DATAFLOAT) &&
         (a->dim==1)) {
-      for (x=0;x<a->rng[0];x++) 
+      for (x=0;x<a->rng[0];x++)
         fit->xrng[slist[x]].w_s_err=a->data.fptr[x];
     }
 
@@ -266,14 +266,14 @@ int FitDecode(struct DataMap *ptr,
 
     if ((strcmp(a->name,"phi0_e")==0) && (a->type==DATAFLOAT) &&
         (a->dim==1)) {
-      for (x=0;x<a->rng[0];x++) 
+      for (x=0;x<a->rng[0];x++)
         fit->xrng[slist[x]].phi0_err=a->data.fptr[x];
     }
 
 
     if ((strcmp(a->name,"elv")==0) && (a->type==DATAFLOAT) &&
         (a->dim==1)) {
-      for (x=0;x<a->rng[0];x++) 
+      for (x=0;x<a->rng[0];x++)
         fit->elv[slist[x]].normal=a->data.fptr[x];
     }
 
@@ -289,20 +289,20 @@ int FitDecode(struct DataMap *ptr,
 
     if ((strcmp(a->name,"x_sd_l")==0) && (a->type==DATAFLOAT) &&
         (a->dim==1)) {
-      for (x=0;x<a->rng[0];x++) 
+      for (x=0;x<a->rng[0];x++)
         fit->xrng[slist[x]].sdev_l=a->data.fptr[x];
     }
     if ((strcmp(a->name,"x_sd_s")==0) && (a->type==DATAFLOAT) &&
         (a->dim==1)) {
-      for (x=0;x<a->rng[0];x++) 
+      for (x=0;x<a->rng[0];x++)
         fit->xrng[slist[x]].sdev_s=a->data.fptr[x];
     }
     if ((strcmp(a->name,"x_sd_phi")==0) && (a->type==DATAFLOAT) &&
         (a->dim==1)) {
-      for (x=0;x<a->rng[0];x++) 
+      for (x=0;x<a->rng[0];x++)
         fit->xrng[slist[x]].sdev_phi=a->data.fptr[x];
     }
-    
+
   }
 
 

--- a/codebase/superdarn/src.lib/tk/radar.1.21/src/rprm.c
+++ b/codebase/superdarn/src.lib/tk/radar.1.21/src/rprm.c
@@ -182,7 +182,6 @@ int RadarParmDecode(struct DataMap *ptr,struct RadarParm *prm) {
   struct DataMapScalar *s;
   struct DataMapArray *a;
 
-  fprintf(stdout,"Within RadarParmDecode\n");
   if (ptr==NULL) return -1;
   if (prm==NULL) return -2;
 
@@ -201,7 +200,6 @@ int RadarParmDecode(struct DataMap *ptr,struct RadarParm *prm) {
 
   prm->ifmode=-1;
 
-  fprintf(stdout,"ptr->snum: %d\n",ptr->snum);
   for (c=0;c<ptr->snum;c++) {
     s=ptr->scl[c];
 
@@ -305,7 +303,6 @@ int RadarParmDecode(struct DataMap *ptr,struct RadarParm *prm) {
 
   }
 
-  fprintf(stdout,"Through first BIG for loop \n");
   for (c=0;c<ptr->anum;c++) {
    a=ptr->arr[c];
    if ((strcmp(a->name,"ptab")==0) && (a->type==DATASHORT) &&
@@ -315,7 +312,6 @@ int RadarParmDecode(struct DataMap *ptr,struct RadarParm *prm) {
         (a->dim==2)) RadarParmSetLag(prm,a->rng[1]-1,a->data.sptr);
   }
 
-  fprintf(stdout,"Through second for loop \n");
   return 0;
 }
 

--- a/codebase/superdarn/src.lib/tk/radar.1.21/src/rprm.c
+++ b/codebase/superdarn/src.lib/tk/radar.1.21/src/rprm.c
@@ -5,26 +5,26 @@
 
 /*
  LICENSE AND DISCLAIMER
- 
+
  Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- 
+
  This file is part of the Radar Software Toolkit (RST).
- 
+
  RST is free software: you can redistribute it and/or modify
  it under the terms of the GNU Lesser General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  any later version.
- 
+
  RST is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU Lesser General Public License for more details.
- 
+
  You should have received a copy of the GNU Lesser General Public License
  along with RST.  If not, see <http://www.gnu.org/licenses/>.
- 
- 
- 
+
+
+
 */
 
 
@@ -44,7 +44,7 @@ struct RadarParm *RadarParmMake() {
 
   ptr=malloc(sizeof(struct RadarParm));
   if (ptr==NULL) return NULL;
-  memset(ptr,0,sizeof(struct RadarParm)); 
+  memset(ptr,0,sizeof(struct RadarParm));
   ptr->origin.time=NULL;
   ptr->origin.command=NULL;
   ptr->pulse=NULL;
@@ -77,7 +77,7 @@ int RadarParmSetOriginTime(struct RadarParm *ptr,char *str) {
 
   if (ptr->origin.time==NULL) tmp=malloc(strlen(str)+1);
   else tmp=realloc(ptr->origin.time,strlen(str)+1);
-  
+
   if (tmp==NULL) return -1;
   strcpy(tmp,str);
   ptr->origin.time=tmp;
@@ -99,9 +99,9 @@ int RadarParmSetOriginCommand(struct RadarParm *ptr,char *str) {
 
   if (ptr->origin.command==NULL) tmp=malloc(strlen(str)+1);
   else tmp=realloc(ptr->origin.command,strlen(str)+1);
- 
+
   if (tmp==NULL) return -1;
-  strcpy(tmp,str); 
+  strcpy(tmp,str);
   ptr->origin.command=tmp;
   return 0;
 
@@ -119,7 +119,7 @@ int RadarParmSetCombf(struct RadarParm *ptr,char *str) {
 
   if (ptr->combf==NULL) tmp=malloc(strlen(str)+1);
   else tmp=realloc(ptr->combf,strlen(str)+1);
- 
+
   if (tmp==NULL) return -1;
   strcpy(tmp,str);
   ptr->combf=tmp;
@@ -160,7 +160,7 @@ int RadarParmSetLag(struct RadarParm *ptr,int mplgs,int16 *lag) {
     }
     return 0;
   }
- 
+
   for (n=0;n<2;n++) {
     if (ptr->lag[n]==NULL) tmp=malloc(sizeof(int16)*(mplgs+1));
     else tmp=realloc(ptr->lag[n],sizeof(int16)*(mplgs+1));
@@ -202,7 +202,7 @@ int RadarParmDecode(struct DataMap *ptr,struct RadarParm *prm) {
 
   for (c=0;c<ptr->snum;c++) {
     s=ptr->scl[c];
-   
+
     if ((strcmp(s->name,"radar.revision.major")==0) && (s->type==DATACHAR))
       prm->revision.major=*(s->data.cptr);
     if ((strcmp(s->name,"radar.revision.minor")==0) && (s->type==DATACHAR))
@@ -210,13 +210,13 @@ int RadarParmDecode(struct DataMap *ptr,struct RadarParm *prm) {
 
     if ((strcmp(s->name,"origin.code")==0) && (s->type==DATACHAR))
       prm->origin.code=*(s->data.cptr);
-    
+
     if ((strcmp(s->name,"origin.time")==0) && (s->type==DATASTRING))
       RadarParmSetOriginTime(prm,*((char **) s->data.vptr));
 
     if ((strcmp(s->name,"origin.command")==0) && (s->type==DATASTRING))
       RadarParmSetOriginCommand(prm,*((char **) s->data.vptr));
-    
+
     if ((strcmp(s->name,"cp")==0) && (s->type==DATASHORT))
       prm->cp=*(s->data.sptr);
     if ((strcmp(s->name,"stid")==0) && (s->type==DATASHORT))
@@ -297,12 +297,12 @@ int RadarParmDecode(struct DataMap *ptr,struct RadarParm *prm) {
       prm->mxpwr=*(s->data.iptr);
     if ((strcmp(s->name,"lvmax")==0) && (s->type==DATAINT))
       prm->lvmax=*(s->data.sptr);
-    
+
     if ((strcmp(s->name,"combf")==0) && (s->type==DATASTRING))
       RadarParmSetCombf(prm,*((char **) s->data.vptr));
-    
+
   }
-  
+
   for (c=0;c<ptr->anum;c++) {
    a=ptr->arr[c];
    if ((strcmp(a->name,"ptab")==0) && (a->type==DATASHORT) &&
@@ -311,13 +311,13 @@ int RadarParmDecode(struct DataMap *ptr,struct RadarParm *prm) {
    if ((strcmp(a->name,"ltab")==0) && (a->type==DATASHORT) &&
         (a->dim==2)) RadarParmSetLag(prm,a->rng[1]-1,a->data.sptr);
   }
-  
+
   return 0;
 }
 
 int RadarParmEncode(struct DataMap *ptr,struct RadarParm *prm) {
 
-  int n,x;  
+  int n,x;
   int16 *pulse=NULL,*lag=NULL;
   int32 pnum;
   int32 lnum[2];
@@ -329,7 +329,7 @@ int RadarParmEncode(struct DataMap *ptr,struct RadarParm *prm) {
 
   DataMapAddScalar(ptr,"radar.revision.major",DATACHAR,&prm->revision.major);
   DataMapAddScalar(ptr,"radar.revision.minor",DATACHAR,&prm->revision.minor);
-  DataMapAddScalar(ptr,"origin.code",DATACHAR,&prm->origin.code);   
+  DataMapAddScalar(ptr,"origin.code",DATACHAR,&prm->origin.code);
   DataMapAddScalar(ptr,"origin.time",DATASTRING,&prm->origin.time);
   DataMapAddScalar(ptr,"origin.command",DATASTRING,&prm->origin.command);
   DataMapAddScalar(ptr,"cp",DATASHORT,&prm->cp);
@@ -377,7 +377,7 @@ int RadarParmEncode(struct DataMap *ptr,struct RadarParm *prm) {
 
   DataMapAddScalar(ptr,"mxpwr",DATAINT,&prm->mxpwr);
   DataMapAddScalar(ptr,"lvmax",DATAINT,&prm->lvmax);
-    
+
   DataMapAddScalar(ptr,"combf",DATASTRING,&prm->combf);
 
   pulse=(int16 *) DataMapStoreArray(ptr,"ptab",DATASHORT,1,&pnum,NULL);
@@ -421,7 +421,7 @@ void *RadarParmFlatten(struct RadarParm *ptr,size_t *size) {
 
   buf=malloc(s);
   if (buf==NULL) return NULL;
-  *size=s; 
+  *size=s;
 
   r=(struct RadarParm *) buf;
   memcpy(buf,ptr,sizeof(struct RadarParm));
@@ -431,20 +431,20 @@ void *RadarParmFlatten(struct RadarParm *ptr,size_t *size) {
     strcpy(buf+p,ptr->origin.time);
     r->origin.time=(void *) p;
     p+=strlen(ptr->origin.time)+1;
-  } 
-      
+  }
+
   if (ptr->origin.command !=NULL) {
     strcpy(buf+p,ptr->origin.command);
     r->origin.command=(void *) p;
     p+=strlen(ptr->origin.command)+1;
-  } 
+  }
 
   if (ptr->combf !=NULL) {
     strcpy(buf+p,ptr->combf);
     r->combf=(void *) p;
     p+=strlen(ptr->combf)+1;
-  } 
-  
+  }
+
   if (ptr->pulse !=NULL) {
     memcpy(buf+p,ptr->pulse,ptr->mppul*sizeof(int16));
     r->pulse=(void *) p;
@@ -480,7 +480,7 @@ int RadarParmExpand(struct RadarParm *ptr,void *buffer) {
     ptr->origin.time=malloc(strlen(p)+1);
     strcpy(ptr->origin.time,p);
   }
-  
+
   if (ptr->origin.command !=NULL) {
     p=buffer+(size_t) ptr->origin.command;
     ptr->origin.command=malloc(strlen(p)+1);
@@ -490,7 +490,7 @@ int RadarParmExpand(struct RadarParm *ptr,void *buffer) {
   if (ptr->combf !=NULL) {
     p=buffer+(size_t) ptr->combf;
     ptr->combf=malloc(strlen(p)+1);
-    strcpy(ptr->combf,p);   
+    strcpy(ptr->combf,p);
   }
 
   if (ptr->pulse !=NULL) {
@@ -503,12 +503,12 @@ int RadarParmExpand(struct RadarParm *ptr,void *buffer) {
     if (ptr->lag[n]==NULL) continue;
     if (ptr->mplgexs !=0) lnum=ptr->mplgexs+1;
     else lnum=ptr->mplgs+1;
-    p=buffer+(size_t) ptr->lag[n]; 
+    p=buffer+(size_t) ptr->lag[n];
     ptr->lag[n]=malloc(lnum*sizeof(int16));
     memcpy(ptr->lag[n],p,lnum*sizeof(int16));
   }
 
- 
+
   return 0;
 }
 

--- a/codebase/superdarn/src.lib/tk/radar.1.21/src/rprm.c
+++ b/codebase/superdarn/src.lib/tk/radar.1.21/src/rprm.c
@@ -182,8 +182,9 @@ int RadarParmDecode(struct DataMap *ptr,struct RadarParm *prm) {
   struct DataMapScalar *s;
   struct DataMapArray *a;
 
+  fprintf(stdout,"Within RadarParmDecode\n");
   if (ptr==NULL) return -1;
-  if (prm==NULL) return -1;
+  if (prm==NULL) return -2;
 
   if (prm->origin.time !=NULL) free(prm->origin.time);
   if (prm->origin.command !=NULL) free(prm->origin.command);
@@ -200,6 +201,7 @@ int RadarParmDecode(struct DataMap *ptr,struct RadarParm *prm) {
 
   prm->ifmode=-1;
 
+  fprintf(stdout,"ptr->snum: %d\n",ptr->snum);
   for (c=0;c<ptr->snum;c++) {
     s=ptr->scl[c];
 
@@ -303,6 +305,7 @@ int RadarParmDecode(struct DataMap *ptr,struct RadarParm *prm) {
 
   }
 
+  fprintf(stdout,"Through first BIG for loop \n");
   for (c=0;c<ptr->anum;c++) {
    a=ptr->arr[c];
    if ((strcmp(a->name,"ptab")==0) && (a->type==DATASHORT) &&
@@ -312,6 +315,7 @@ int RadarParmDecode(struct DataMap *ptr,struct RadarParm *prm) {
         (a->dim==2)) RadarParmSetLag(prm,a->rng[1]-1,a->data.sptr);
   }
 
+  fprintf(stdout,"Through second for loop \n");
   return 0;
 }
 


### PR DESCRIPTION
Noticed that the fitstat function was not working and would either seg fault or execute without giving the printout of the stats that it promises.  

Here you'll see changes to 3 files, fitstat.c and two others.  Most of the changes are removing unnecessary spaces.  However, I also modified the rprm.c file to give a different return value if the prm pointer is null within RadarParmDecode().  This gives a little bit better of an error check as to which one is null.

In fitstat, the main problem is that the prm, fit pointers are initialized, but not "built" or filled in with objects.  However adding: `prm=RadarParmMake();` and `fit=FitMake();` clears up the seg fault issue and things run normally.  In this file, I also added an error output if the bmcnt isn't greater than zero.  Before it would just exit.

The expected output is (and some test code):

```
~/$ fitstat -new 20160515.0402.00.bks.fitacf
20160515.0402.00.bks.fitacf:2016 05 15 04 02 00:2016 05 15 06 01 44 [33] (2220)

~/$ fitstat 2005101110g.fit
2005101110g.fit:2005 10 11 10 02 00:2005 10 11 12 01 47 [01] (960)
```

This will not work on the current code in the develop branch.