### PR TITLE
Prevent missing/empty BUILD env. variable from deleting /{bin,lib}/*

### DIFF
--- a/build/script/make.build
+++ b/build/script/make.build
@@ -21,6 +21,11 @@ set -e
 
 ############################################################################
 
+if [ -z "$BUILD" ]; then
+    echo "BUILD environment variable is empty, please set"
+    exit 1
+fi
+
 export LD_LIBRARY_PATH=${BUILD}/lib
 export BINPATH=${BUILD}/bin
 export LIBPATH=${BUILD}/lib


### PR DESCRIPTION
Fixes issue #17 